### PR TITLE
Allow colored terminal output on Windows if ENABLE_VIRTUAL_TERMINAL_PROCESSING is set

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1139,6 +1139,18 @@ std::string OS::currentHost(void) {
 }
 
 bool OS::termSupportsColor(void) {
+#if ELPP_OS_WINDOWS && defined(ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+  HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+  if (stdoutHandle != INVALID_HANDLE_VALUE && stdoutHandle != NULL) {
+    DWORD mode;
+    if (GetConsoleMode(stdoutHandle, &mode)) {
+      if ((mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0
+          && (mode & ENABLE_PROCESSED_OUTPUT) != 0) {
+        return true;
+      }
+    }
+  }
+#endif
   std::string term = getEnvironmentVariable("TERM", "");
   return term == "xterm" || term == "xterm-color" || term == "xterm-256color"
          || term == "screen" || term == "linux" || term == "cygwin"


### PR DESCRIPTION
This improves the compatibility of the `LoggingFlag::ColoredTerminalOutput` setting on Windows.

Windows 10 and later introduced virtual terminal support in conhost and Windows Terminal. This adds logic to easylogging++ to detect when virtual terminal processing is enabled, to allow colored output if the flag is set.

E.g. running the all-logs sample in Windows Terminal:

<img width="867" alt="image" src="https://github.com/abumq/easyloggingpp/assets/15180557/ce6ade84-8716-46ab-b840-ee8c288e5b8a">

### This is a

- [ ] Breaking change
- [x] New feature
- [ ] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [x] [Run the tests](README.md#install-optional)
