### PR TITLE
fix(compilation): fix g++13.2 compiler warnings about const references

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1897,7 +1897,7 @@ Logger* RegisteredLoggers::get(const std::string& id, bool forceCreation) {
     logger_->m_logBuilder = m_defaultLogBuilder;
     registerNew(id, logger_);
     LoggerRegistrationCallback* callback = nullptr;
-    for (const std::pair<std::string, base::type::LoggerRegistrationCallbackPtr>& h
+    for (const std::pair<const std::string, base::type::LoggerRegistrationCallbackPtr>& h
          : m_loggerRegistrationCallbacks) {
       callback = h.second.get();
       if (callback != nullptr && callback->enabled()) {
@@ -2489,7 +2489,7 @@ void LogDispatcher::dispatch(void) {
   }
   LogDispatchCallback* callback = nullptr;
   LogDispatchData data;
-  for (const std::pair<std::string, base::type::LogDispatchCallbackPtr>& h
+  for (const std::pair<const std::string, base::type::LogDispatchCallbackPtr>& h
        : ELPP->m_logDispatchCallbacks) {
     callback = h.second.get();
     if (callback != nullptr && callback->enabled()) {


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

solves #845

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
