### PR TITLE
fix: QString cannot directly print non-English (e.g. Chinese)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,11 +1117,11 @@ Easylogging++ has complete logging support for Qt core library. When enabled, th
 
 Following Qt classes and containers are supported by Easylogging++ v9.0+
 
-|     *         |          *                |       *            |         *          |         *          |         *          |
-|---------------|---------------------------|--------------------|--------------------|--------------------|--------------------|
-| `QString`     |  `QByteArray`             |  `QLatin`          |    `QList`         |    `QVector`       |    `QQueue`        |
-| `QSet`        |  `QPair`                  |  `QMap`            |    `QMultiMap`     |    `QHash`         |    `QMultiHash`    |
-| `QLinkedList` |  `QStack`                 |  `QChar`           |    `q[u]int[64]`   |                    |                    |
+| *             | *            | *        | *             | *         | *            |
+| ------------- | ------------ | -------- | ------------- | --------- | ------------ |
+| `QString`     | `QByteArray` | `QLatin` | `QList`       | `QVector` | `QQueue`     |
+| `QSet`        | `QPair`      | `QMap`   | `QMultiMap`   | `QHash`   | `QMultiHash` |
+| `QLinkedList` | `QStack`     | `QChar`  | `q[u]int[64]` | `QRect`   |              |
 
 Similar to STL logging, Qt containers are also limit to log 100 entries per log, you can change this behaviour by changing base::consts::kMaxLogPerContainer from header but this is not recommended as this was done for performance purposes.
 

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -430,6 +430,7 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #if defined(ELPP_QT_LOGGING)
 // For logging Qt based classes & templates
 #   include <QString>
+#   include <QRect>
 #   include <QByteArray>
 #   include <QVector>
 #   include <QList>
@@ -2987,8 +2988,22 @@ return writeIterator(template_inst.begin(), template_inst.end(), template_inst.s
 #  if defined(ELPP_UNICODE)
     m_logger->stream() << msg.toStdWString();
 #  else
-    m_logger->stream() << msg.toStdString();
+    m_logger->stream() << msg.toLocal8Bit().toStdString();
 #  endif  // defined(ELPP_UNICODE)
+    return *this;
+  }
+  inline MessageBuilder& operator<<(const QRect& rect) {
+    const int& left = rect.left();
+    const int& top = rect.top();
+    const int& width = rect.width();
+    const int& height = rect.height();
+#  if defined(ELPP_UNICODE)
+    #define int2wstr(name) QString::number(name).toStdWString()
+    m_logger->stream() << L"QRect(" << int2wstr(left) << L"," << int2wstr(top) << L" " << int2wstr(width) << L"x" << int2wstr(height) << L")";
+#  else
+    #define int2str(name) QString::number(name).toLocal8Bit().toStdString()
+    m_logger->stream() << "QRect(" << int2str(left) << "," << int2str(top) << " " << int2str(width) << "x" << int2str(height) << ")";
+#  endif
     return *this;
   }
   inline MessageBuilder& operator<<(const QByteArray& msg) {


### PR DESCRIPTION
and provides direct printing of common `QRect` types.

### This is a

- [ ] Breaking change
- [x] New feature
- [x] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [x] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
